### PR TITLE
Support Pylint v3

### DIFF
--- a/pylint_absolute_imports/checker.py
+++ b/pylint_absolute_imports/checker.py
@@ -1,7 +1,9 @@
 """Strict check of the import."""
 from astroid import ImportFrom  # type: ignore
-from pylint.interfaces import IAstroidChecker  # type: ignore
 from pylint.checkers import BaseChecker  # type: ignore
+import pylint
+
+PYLINT_VERSION_MAJOR = int(pylint.__version__.split(".", maxsplit=1)[0])
 
 
 def is_relative(node: ImportFrom) -> bool:
@@ -13,7 +15,11 @@ class AbsoluteImportChecker(BaseChecker):
 
     """Pylint checker for imports."""
 
-    __implements__ = IAstroidChecker
+    if PYLINT_VERSION_MAJOR < 3:
+        # pylint: disable-next=import-outside-toplevel,no-name-in-module
+        from pylint.interfaces import IAstroidChecker
+
+        __implements__ = IAstroidChecker
 
     name = 'relative-import'
     priority = -1

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         'Programming Language :: Python :: 3',
     ),
     install_requires=(
-        'pylint>=2.5.0,<3',
+        'pylint>=2.5.0,<4',
     )
 )


### PR DESCRIPTION
# Background

[pylint_absolute_imports](https://github.com/QuentinN42/pylint_absolute_imports) only supports Pylint <3 at the moment. This PR add support for Pylint v3 and up

Related PR: https://github.com/pylint-dev/pylint-pytest/pull/27